### PR TITLE
Adding edge encoding utility

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,3 +38,61 @@ end
 Base.IteratorSize(::Type{mappingnodes}) = Base.SizeUnknown()
 Base.eltype(::Type{mappingnodes}) = PN.Node
 # see https://docs.julialang.org/en/v1/manual/interfaces/ for interators
+
+
+"""
+encode_edges!(gene tree, species tree)
+
+Given a gene tree with labeled internal nodes that map to a species phylogeny,
+this function maps each gene edge to the species edge that it is contained "within".
+Gene edge mappings are stored in the `inCycle` field of each gene tree `Edge`.
+
+The `checknames` argument takes a boolean, and, if `true`, 
+then the function will check that both the species and the gene phylogeny
+have the same internal node names to create a mapping.
+"""
+
+function encode_edges!(gene::PN.HybridNetwork,species::PN.HybridNetwork,checknames=true::Bool)
+    #Get all named non-leaf nodes on the gene tree.
+    search_nds = gene.node[(x->x.name != "" && !x.leaf).(gene.node)] ##These are the  nodes that we will traverse for edge groups
+    if checknames
+        gene_nodenames = (x->x.name).(gene.node)
+        species_nodenames = push!((x->x.name).(species.node),"")
+        !issetequal(species_nodenames,gene_nodenames) && error("The gene and species phylogeny have different sets of node names")
+    end ##else assume only node corresponding to the species tree are named in the gene tree
+    gene.node[gene.root].name == "" && push!(search_nds,gene.node[gene.root]) ## if not named, also add the root as a starting point
+
+    # dictionary that tracks all edges found within a given species edge
+    # Species edges are defined by the named parent and child nodes
+    edge_groups = Dict{Tuple{String,String},Vector{PhyloNetworks.Edge}}()
+    edge_group_sp_names= (x->(PN.getparent(x).name,PN.getchild(x).name)).(species.edge)
+    push!(edge_group_sp_names,(gene.node[gene.root].name,species.node[species.root].name)) ## Add an edge group for the 'root edge' to handle coalescences beyond the species root. 
+    (x -> edge_groups[x]=Vector{PhyloNetworks.Edge}()).(edge_group_sp_names) # initialize edge groups with empty vectors. 
+
+    for search_nd in search_nds 
+        nd_group = PN.getchildren(search_nd) # The nodes found within an edge group
+        edge_group = PN.Edge[]
+        chld_name = nothing # The name of the child node of the species edge
+        for nd in nd_group
+            push!(edge_group,PN.getparentedge(nd))
+            if nd.name==""
+               append!(nd_group,PN.getchildren(nd)) 
+            else
+                if isnothing(chld_name)
+                    chld_name=nd.name
+                else
+                   chld_name != nd.name && error("Found two different child names of the species edge within an edge group.") 
+                end
+            end
+        end
+        append!(edge_groups[(search_nd.name,chld_name)],edge_group)
+    end
+
+    inCycle_nos = (x-> x.number ).(species.edge)
+    inCycle_nos = push!(inCycle_nos,length(species.edge)+1)
+    for (number,e_names) in zip(inCycle_nos,edge_group_sp_names)
+        gene_edges = edge_groups[e_names]
+        (x-> x.inCycle = number).(gene_edges)
+    end
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ const PCS = PhyloCoalSimulations
 @testset "PhyloCoalSimulations.jl" begin
     include("test_onepopulation.jl")
     include("test_multispeciesnetwork.jl")
+    include("test_utils.jl")
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -12,3 +12,5 @@ message = "The gene and species phylogeny have different sets of node names"
 tree.node[1].name = "B"
 
 PCS.encode_edges!(tree,net)
+
+@test (x-> x.inCycle).(tree.edge) == [2,5,7,8,1,4,8,6,7,8,8]

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,14 @@
+net = readTopology("((C:0.9,(B:0.2)#H1:0.7::0.6):0.6,(#H1:0.6,A:1):0.5);");
+PN.nameinternalnodes!(net, "i"); # "i" is a prefix to name internal nodes
+
+rng = StableRNG(7)
+
+tree = readTopology(writeTopology(simulatecoalescent(rng, net,1,1; nodemapping=true)[1]))
+
+tree.node[1].name = "a name not in the species phylogeny" # give an incorrect name
+message = "The gene and species phylogeny have different sets of node names"
+@test_throws ErrorException(message) PCS.encode_edges!(tree,net)
+
+tree.node[1].name = "B"
+
+PCS.encode_edges!(tree,net)


### PR DESCRIPTION
If wanted, here is a utility function for remapping the species edges onto the gene edges after reading in the gene tree.

Some of the stuff I've been working on uses the edge mappings and these mappings are lost when reading/writing the gene trees.

Let me know if  this seems useful but you want more tests, documentation, clarification, etc. 